### PR TITLE
use XML instead of annotations for Doctrine mapping to allow overriding it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,10 @@ env:
 
 matrix:
   include:
-    - php: 5.3.3
-      env: DEPS='lowest'
+    - php: 5.3
+      env: DEPS='lowest' SYMFONY_DEPRECATIONS_HELPER='666'
     - php: 5.6
       env: DEPS='unmodified'
-    - php: 5.6
-      env: SYMFONY_VERSION='2.3.*' SYMFONY_DEPRECATIONS_HELPER='666'
     - php: 5.6
       env: SYMFONY_VERSION='2.8.*'
     - php: 5.6
@@ -39,7 +37,7 @@ install:
   # disable Xdebug for better Composer performance
   - if [ "${TRAVIS_PHP_VERSION}" != 'hhvm' ]; then mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini xdebug.ini; fi;
   # install dependencies using Composer
-  - travis_wait bash .travis_install_dependencies.sh
+  - bash .travis_install_dependencies.sh
 
 before_script:
   # ensure MySQL database exists

--- a/.travis_install_dependencies.sh
+++ b/.travis_install_dependencies.sh
@@ -3,12 +3,6 @@
 set -euv
 
 export COMPOSER_NO_INTERACTION=1
-
-if [ "${TRAVIS_PHP_VERSION}" = '5.3.3' ]; then
-	composer config -g disable-tls true
-	composer config -g secure-http false
-fi
-
 composer self-update
 
 case "${DEPS:-}" in

--- a/Controller/SettingsController.php
+++ b/Controller/SettingsController.php
@@ -2,7 +2,7 @@
 
 namespace Craue\ConfigBundle\Controller;
 
-use Craue\ConfigBundle\Entity\Setting;
+use Craue\ConfigBundle\Entity\SettingInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -15,7 +15,7 @@ class SettingsController extends Controller {
 
 	public function modifyAction(Request $request) {
 		$em = $this->getDoctrine()->getManager();
-		$repo = $em->getRepository('Craue\ConfigBundle\Entity\Setting');
+		$repo = $em->getRepository($this->container->getParameter('craue_config.entity_name'));
 		$allStoredSettings = $repo->findAll();
 		$cache = $this->container->get('craue_config_cache_adapter');
 
@@ -53,7 +53,7 @@ class SettingsController extends Controller {
 	}
 
 	/**
-	 * @param Setting[] $settings
+	 * @param SettingInterface[] $settings
 	 * @return string[] (may also contain a null value)
 	 */
 	protected function getSections(array $settings) {
@@ -72,9 +72,9 @@ class SettingsController extends Controller {
 	}
 
 	/**
-	 * @param Setting[] $settings
+	 * @param SettingInterface[] $settings
 	 * @param string $name
-	 * @return Setting|null
+	 * @return SettingInterface|null
 	 */
 	protected function getSettingByName(array $settings, $name) {
 		foreach ($settings as $setting) {

--- a/CraueConfigBundle.php
+++ b/CraueConfigBundle.php
@@ -2,6 +2,8 @@
 
 namespace Craue\ConfigBundle;
 
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -10,4 +12,24 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @license http://opensource.org/licenses/mit-license.php MIT License
  */
 class CraueConfigBundle extends Bundle {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function build(ContainerBuilder $container) {
+		parent::build($container);
+		$this->addRegisterMappingsPass($container);
+	}
+
+	/**
+	 * @param ContainerBuilder $container
+	 */
+	private function addRegisterMappingsPass(ContainerBuilder $container) {
+		$mappings = array(
+			realpath(__DIR__ . '/Resources/config/doctrine-mapping') => 'Craue\ConfigBundle\Entity',
+		);
+
+		$container->addCompilerPass(DoctrineOrmMappingsPass::createXmlMappingDriver($mappings, array(), 'craue_config.db_driver.doctrine_orm'));
+	}
+
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Craue\ConfigBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * Configuration for the bundle.
+ *
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2017 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class Configuration implements ConfigurationInterface {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getConfigTreeBuilder() {
+		$supportedDrivers = array('doctrine_orm');
+
+		$treeBuilder = new TreeBuilder();
+		$treeBuilder->root('craue_config')
+			->children()
+				// TODO replace by `->enumNode('db_driver')->values($supportedDrivers)->defaultValue($supportedDrivers[0])->end()` when at least two values are defined or as soon as Symfony >= 3.1 is required
+				->scalarNode('db_driver')
+					->defaultValue($supportedDrivers[0])
+					->validate()
+						->ifNotInArray($supportedDrivers)
+						->thenInvalid('The driver "%s" is not supported. Please choose one of ' . json_encode($supportedDrivers))
+					->end()
+				->end()
+				->scalarNode('entity_name')
+					->defaultValue('Craue\ConfigBundle\Entity\Setting')
+				->end()
+			->end()
+		;
+
+		return $treeBuilder;
+	}
+
+}

--- a/DependencyInjection/CraueConfigExtension.php
+++ b/DependencyInjection/CraueConfigExtension.php
@@ -2,6 +2,7 @@
 
 namespace Craue\ConfigBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -19,11 +20,19 @@ class CraueConfigExtension extends Extension {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function load(array $config, ContainerBuilder $container) {
+	public function load(array $configs, ContainerBuilder $container) {
+		$processor = new Processor();
+		$config = $processor->processConfiguration(new Configuration(), $configs);
+
+		$container->setParameter('craue_config.db_driver.' . $config['db_driver'], true);
+		$container->setParameter('craue_config.entity_name', $config['entity_name']);
+
 		$loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
 		if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
 			$loader->load('form_legacy.xml'); // for symfony/form < 2.8
+		} else {
+			$loader->load('form.xml');
 		}
 
 		$loader->load('twig.xml');

--- a/Entity/BaseSetting.php
+++ b/Entity/BaseSetting.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Craue\ConfigBundle\Entity;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2017 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+abstract class BaseSetting implements SettingInterface {
+
+	/**
+	 * @var string
+	 * @Assert\NotBlank
+	 */
+	protected $name;
+
+	/**
+	 * @var string|null
+	 */
+	protected $value;
+
+	/**
+	 * @var string|null
+	 */
+	protected $section;
+
+	public function setName($name) {
+		$this->name = $name;
+	}
+
+	public function getName() {
+		return $this->name;
+	}
+
+	public function setValue($value) {
+		$this->value = $value;
+	}
+
+	public function getValue() {
+		return $this->value;
+	}
+
+	public function setSection($section) {
+		$this->section = $section;
+	}
+
+	public function getSection() {
+		return $this->section;
+	}
+
+	/**
+	 * Creates a {@code SettingInterface}.
+	 * @param string $name
+	 * @param string|null $value
+	 * @param string|null $section
+	 * @return SettingInterface
+	 */
+	public static function create($name, $value = null, $section = null) {
+		$setting = new static();
+		$setting->setName($name);
+		$setting->setValue($value);
+		$setting->setSection($section);
+
+		return $setting;
+	}
+
+}

--- a/Entity/SettingInterface.php
+++ b/Entity/SettingInterface.php
@@ -7,5 +7,15 @@ namespace Craue\ConfigBundle\Entity;
  * @copyright 2011-2017 Christian Raue
  * @license http://opensource.org/licenses/mit-license.php MIT License
  */
-class Setting extends BaseSetting {
+interface SettingInterface {
+
+	function setName($name);
+	function getName();
+
+	function setValue($value);
+	function getValue();
+
+	function setSection($section);
+	function getSection();
+
 }

--- a/Form/Type/SettingType.php
+++ b/Form/Type/SettingType.php
@@ -2,6 +2,7 @@
 
 namespace Craue\ConfigBundle\Form\Type;
 
+use Craue\ConfigBundle\Entity\SettingInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -17,12 +18,19 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 class SettingType extends AbstractType {
 
 	/**
+	 * @var string
+	 */
+	protected $entityName;
+
+	public function __construct($entityName) {
+		$this->entityName = $entityName;
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function buildForm(FormBuilderInterface $builder, array $options) {
-		$useFqcn = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
-
-		$builder->add('value', $useFqcn ? 'Symfony\Component\Form\Extension\Core\Type\TextType' : 'text', array(
+		$builder->add('value', null, array(
 			'required' => false,
 			'translation_domain' => 'CraueConfigBundle',
 		));
@@ -32,7 +40,7 @@ class SettingType extends AbstractType {
 	 * {@inheritdoc}
 	 */
 	public function finishView(FormView $view, FormInterface $form, array $options) {
-		/* @var $setting Setting */
+		/* @var $setting SettingInterface */
 		$setting = $form->getData();
 
 		$view->children['value']->vars['label'] = $setting->getName();
@@ -43,7 +51,7 @@ class SettingType extends AbstractType {
 	 */
 	public function configureOptions(OptionsResolver $resolver) {
 		$resolver->setDefaults(array(
-			'data_class' => 'Craue\ConfigBundle\Entity\Setting',
+			'data_class' => $this->entityName,
 		));
 	}
 

--- a/Form/Type/SettingType.php
+++ b/Form/Type/SettingType.php
@@ -8,7 +8,6 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * @author Christian Raue <christian.raue@gmail.com>
@@ -53,13 +52,6 @@ class SettingType extends AbstractType {
 		$resolver->setDefaults(array(
 			'data_class' => $this->entityName,
 		));
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function setDefaultOptions(OptionsResolverInterface $resolver) {
-		$this->configureOptions($resolver);
 	}
 
 	/**

--- a/README.md
+++ b/README.md
@@ -222,3 +222,53 @@ name-of-a-setting: name of the setting
 # in app/Resources/CraueConfigBundle/translations/CraueConfigBundle.de.yml
 name-of-a-setting: Name der Einstellung
 ```
+
+## Using a custom entity for settings
+
+The custom entity has to provide a mapping for the field `value`. The class `BaseSetting` defines this field, but no
+mapping for it. This allows easy overriding, including the data type. In the following example, the `value` field will
+be mapped to a `text` column, which will in turn render the built-in form fields as `textarea`.
+
+So create the entity and its appropriate mapping:
+
+```php
+// src/MyCompany/MyBundle/Entity/MySetting.php
+use Craue\ConfigBundle\Entity\BaseSetting;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="Craue\ConfigBundle\Repository\SettingRepository")
+ * @ORM\Table(name="my_setting")
+ */
+class MySetting extends BaseSetting {
+
+	/**
+	 * @var string|null
+	 * @ORM\Column(name="value", type="text", nullable=true)
+	 */
+	protected $value;
+
+	/**
+	 * @var string|null
+	 * @ORM\Column(name="comment", type="string", nullable=true)
+	 */
+	protected $comment;
+
+	public function setComment($comment) {
+		$this->comment = $comment;
+	}
+
+	public function getComment() {
+		return $this->comment;
+	}
+
+}
+```
+
+And make the bundle aware of it:
+
+```yaml
+# in app/config/config.yml
+craue_config:
+  entity_name: MyCompany\MyBundle\Entity\MySetting
+```

--- a/Repository/SettingRepository.php
+++ b/Repository/SettingRepository.php
@@ -2,7 +2,7 @@
 
 namespace Craue\ConfigBundle\Repository;
 
-use Craue\ConfigBundle\Entity\Setting;
+use Craue\ConfigBundle\Entity\SettingInterface;
 use Doctrine\ORM\EntityRepository;
 
 /**
@@ -14,12 +14,12 @@ class SettingRepository extends EntityRepository {
 
 	/**
 	 * @param string[] $names
-	 * @return Setting[] Array of settings, indexed by name.
+	 * @return SettingInterface[] Array of settings, indexed by name.
 	 */
 	public function findByNames(array $names) {
 		return $this->getEntityManager()->createQueryBuilder()
 			->select('s')
-			->from('Craue\ConfigBundle\Entity\Setting', 's', 's.name')
+			->from($this->getEntityName(), 's', 's.name')
 			->where('s.name IN (:names)')
 			->getQuery()
 			->execute(array('names' => $names))

--- a/Resources/config/doctrine-mapping/BaseSetting.orm.xml
+++ b/Resources/config/doctrine-mapping/BaseSetting.orm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+	Author: Christian Raue <christian.raue@gmail.com>
+	Copyright: 2011-2017 Christian Raue
+	License: http://opensource.org/licenses/mit-license.php MIT License
+-->
+<doctrine-mapping
+	xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+	<mapped-superclass name="Craue\ConfigBundle\Entity\BaseSetting">
+		<id name="name" column="name" type="string" />
+		<!-- Define the mapping for field "value" only in child classes to allow easy overriding. -->
+		<field name="section" column="section" type="string" nullable="true" />
+	</mapped-superclass>
+</doctrine-mapping>

--- a/Resources/config/doctrine-mapping/Setting.orm.xml
+++ b/Resources/config/doctrine-mapping/Setting.orm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+	Author: Christian Raue <christian.raue@gmail.com>
+	Copyright: 2011-2017 Christian Raue
+	License: http://opensource.org/licenses/mit-license.php MIT License
+-->
+<doctrine-mapping
+	xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+	<entity name="Craue\ConfigBundle\Entity\Setting" repository-class="Craue\ConfigBundle\Repository\SettingRepository" table="craue_config_setting">
+		<field name="value" column="value" type="string" nullable="true" />
+	</entity>
+</doctrine-mapping>

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -10,12 +10,8 @@
 		xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 	<services>
 		<service id="craue_config.form_type.setting" class="Craue\ConfigBundle\Form\Type\SettingType">
-			<tag name="form.type" alias="craue_config_setting" />
+			<tag name="form.type" />
 			<argument>%craue_config.entity_name%</argument>
-		</service>
-
-		<service id="craue_config.form.modifySettings" class="Craue\ConfigBundle\Form\ModifySettingsForm">
-			<tag name="form.type" alias="craue_config_modifySettings" />
 		</service>
 	</services>
 </container>

--- a/Resources/config/util.xml
+++ b/Resources/config/util.xml
@@ -18,11 +18,16 @@
 			<argument type="service" id="craue_config_cache_provider" on-invalid="ignore" />
 		</service>
 
-		<service id="craue_config" class="Craue\ConfigBundle\Util\Config">
+		<service id="craue_config_default" class="Craue\ConfigBundle\Util\Config">
 			<argument type="service" id="craue_config_cache_adapter" />
 			<call method="setEntityManager">
 				<argument type="service" id="doctrine.orm.default_entity_manager" />
 			</call>
+			<call method="setEntityName">
+				<argument>%craue_config.entity_name%</argument>
+			</call>
 		</service>
+
+		<service id="craue_config" alias="craue_config_default" />
 	</services>
 </container>

--- a/Tests/Controller/DebugControllerTest.php
+++ b/Tests/Controller/DebugControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Craue\ConfigBundle\Tests\Controller;
 
+use Craue\ConfigBundle\Entity\Setting;
 use Craue\ConfigBundle\Tests\IntegrationTestCase;
 use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
 use Symfony\Bundle\FrameworkBundle\Client;
@@ -22,7 +23,7 @@ class DebugControllerTest extends IntegrationTestCase {
 	 */
 	public function testGetAction_severalRequests($platform, $config, $requiredExtension, $environment) {
 		$client = $this->initClient($requiredExtension, array('environment' => $environment . '_' . $platform, 'config' => $config));
-		$this->persistSetting('name1', 'value1');
+		$this->persistSetting(Setting::create('name1', 'value1'));
 
 		$cache = $client->getContainer()->get('craue_config_cache_adapter');
 		$cache->clear();

--- a/Tests/Controller/SettingsControllerIntegrationTest.php
+++ b/Tests/Controller/SettingsControllerIntegrationTest.php
@@ -143,9 +143,6 @@ class SettingsControllerIntegrationTest extends IntegrationTestCase {
 		$crawler = $client->request('GET', $this->url($client, 'craue_config_settings_modify'));
 		$form = $crawler->selectButton('apply')->form();
 		$form->remove('craue_config_modifySettings[settings][0][value]');
-		if ($form->has('craue_config_modifySettings[_token]')) {
-			$form->remove('craue_config_modifySettings[_token]'); // field only present in older Symfony versions, removal needed to make form submission invalid
-		}
 		$client->followRedirects();
 		$client->submit($form);
 		$content = $client->getResponse()->getContent();
@@ -168,9 +165,7 @@ class SettingsControllerIntegrationTest extends IntegrationTestCase {
 		$this->assertContains('<label for="craue_config_modifySettings_settings_0_value">setting no. 1</label>', $content);
 
 		$profile = $client->getProfile();
-		if ($profile->hasCollector('translation')) { // TODO remove as soon as Symfony >= 2.7 is required
-			$this->assertSame(0, $profile->getCollector('translation')->getCountMissings());
-		}
+		$this->assertSame(0, $profile->getCollector('translation')->getCountMissings());
 	}
 
 	/**

--- a/Tests/IntegrationTestBundle/Entity/CustomSetting.php
+++ b/Tests/IntegrationTestBundle/Entity/CustomSetting.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Craue\ConfigBundle\Tests\IntegrationTestBundle\Entity;
+
+use Craue\ConfigBundle\Entity\BaseSetting;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2017 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class CustomSetting extends BaseSetting {
+
+	/**
+	 * @var string|null
+	 */
+	protected $comment;
+
+	public function setComment($comment) {
+		$this->comment = $comment;
+	}
+
+	public function getComment() {
+		return $this->comment;
+	}
+
+	/**
+	 * Creates a {@code CustomSetting}.
+	 * @param string $name
+	 * @param string|null $value
+	 * @param string|null $section
+	 * @param string|null $comment
+	 * @return CustomSetting
+	 */
+	public static function create($name, $value = null, $section = null, $comment = null) {
+		$setting = parent::create($name, $value, $section);
+		$setting->setComment($comment);
+
+		return $setting;
+	}
+
+}

--- a/Tests/IntegrationTestBundle/Resources/config/doctrine/CustomSetting.orm.xml
+++ b/Tests/IntegrationTestBundle/Resources/config/doctrine/CustomSetting.orm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+	Author: Christian Raue <christian.raue@gmail.com>
+	Copyright: 2011-2017 Christian Raue
+	License: http://opensource.org/licenses/mit-license.php MIT License
+-->
+<doctrine-mapping
+	xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+	<entity name="Craue\ConfigBundle\Tests\IntegrationTestBundle\Entity\CustomSetting" repository-class="Craue\ConfigBundle\Repository\SettingRepository" table="craue_config_setting_custom">
+		<field name="value" column="value" type="text" nullable="true" />
+		<field name="comment" column="comment" type="string" nullable="true" />
+	</entity>
+</doctrine-mapping>

--- a/Tests/IntegrationTestBundle/Util/CustomConfig.php
+++ b/Tests/IntegrationTestBundle/Util/CustomConfig.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Craue\ConfigBundle\Tests\IntegrationTestBundle\Util;
+
+use Craue\ConfigBundle\Tests\IntegrationTestBundle\Entity\CustomSetting;
+use Craue\ConfigBundle\Util\Config;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2017 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class CustomConfig extends Config {
+
+	/**
+	 * @param string $name Name of the setting.
+	 * @return CustomSetting The setting object.
+	 * @throws \RuntimeException If the setting is not defined.
+	 */
+	public function getRawSetting($name) {
+		$setting = $this->getRepo()->findOneBy(array(
+			'name' => $name,
+		));
+
+		if ($setting === null) {
+			throw $this->createNotFoundException($name);
+		}
+
+		return $setting;
+	}
+
+}

--- a/Tests/IntegrationTestCase.php
+++ b/Tests/IntegrationTestCase.php
@@ -2,7 +2,7 @@
 
 namespace Craue\ConfigBundle\Tests;
 
-use Craue\ConfigBundle\Entity\Setting;
+use Craue\ConfigBundle\Entity\SettingInterface;
 use Craue\ConfigBundle\Repository\SettingRepository;
 use Craue\ConfigBundle\Twig\Extension\ConfigTemplateExtension;
 use Craue\ConfigBundle\Util\Config;
@@ -110,15 +110,10 @@ abstract class IntegrationTestCase extends WebTestCase {
 	}
 
 	/**
-	 * Persists a {@code Setting}.
-	 * @param string $name
-	 * @param string|null $value
-	 * @param string|null $section
-	 * @return Setting
+	 * @param $setting SettingInterface The setting to persist.
+	 * @return SettingInterface The persisted setting.
 	 */
-	protected function persistSetting($name, $value = null, $section = null) {
-		$setting = Setting::create($name, $value, $section);
-
+	protected function persistSetting(SettingInterface $setting) {
 		$em = $this->getEntityManager();
 		$em->persist($setting);
 		$em->flush();
@@ -164,7 +159,7 @@ abstract class IntegrationTestCase extends WebTestCase {
 	 * @return SettingRepository
 	 */
 	protected function getSettingsRepo() {
-		return $this->getEntityManager()->getRepository('Craue\ConfigBundle\Entity\Setting');
+		return $this->getEntityManager()->getRepository(static::$kernel->getContainer()->getParameter('craue_config.entity_name'));
 	}
 
 	/**

--- a/Tests/Repository/SettingRepositoryTest.php
+++ b/Tests/Repository/SettingRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Craue\ConfigBundle\Tests\Repository;
 
+use Craue\ConfigBundle\Entity\Setting;
 use Craue\ConfigBundle\Tests\IntegrationTestCase;
 
 /**
@@ -19,8 +20,8 @@ class SettingRepositoryTest extends IntegrationTestCase {
 	public function testFindByNames($platform, $config, $requiredExtension) {
 		$this->initClient($requiredExtension, array('environment' => $platform, 'config' => $config));
 
-		$setting1 = $this->persistSetting('name1');
-		$setting2 = $this->persistSetting('name2');
+		$setting1 = $this->persistSetting(Setting::create('name1'));
+		$setting2 = $this->persistSetting(Setting::create('name2'));
 
 		$repo = $this->getSettingsRepo();
 

--- a/Tests/Twig/Extension/ConfigTemplateExtensionIntegrationTest.php
+++ b/Tests/Twig/Extension/ConfigTemplateExtensionIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Craue\ConfigBundle\Tests\Twig\Extension;
 
+use Craue\ConfigBundle\Entity\Setting;
 use Craue\ConfigBundle\Tests\IntegrationTestCase;
 
 /**
@@ -18,7 +19,7 @@ class ConfigTemplateExtensionIntegrationTest extends IntegrationTestCase {
 	 */
 	public function testSettingFunction($platform, $config, $requiredExtension, $name, $value) {
 		$this->initClient($requiredExtension, array('environment' => $platform, 'config' => $config));
-		$this->persistSetting($name, $value);
+		$this->persistSetting(Setting::create($name, $value));
 
 		$this->assertSame($value, $this->getTwig()->render('@IntegrationTest/Settings/setting.html.twig', array(
 			'name' => $name,

--- a/Tests/Util/ConfigIntegrationTest.php
+++ b/Tests/Util/ConfigIntegrationTest.php
@@ -2,6 +2,8 @@
 
 namespace Craue\ConfigBundle\Tests\Util;
 
+use Craue\ConfigBundle\Entity\Setting;
+use Craue\ConfigBundle\Tests\IntegrationTestBundle\Entity\CustomSetting;
 use Craue\ConfigBundle\Tests\IntegrationTestCase;
 
 /**
@@ -22,7 +24,7 @@ class ConfigIntegrationTest extends IntegrationTestCase {
 		$client = $this->initClient($requiredExtension, array('environment' => $environment . '_' . $platform, 'config' => $config));
 		$container = $client->getContainer();
 
-		$this->persistSetting('name', 'value');
+		$this->persistSetting(Setting::create('name', 'value'));
 
 		$container->get('craue_config')->all();
 
@@ -43,6 +45,69 @@ class ConfigIntegrationTest extends IntegrationTestCase {
 		}
 
 		return $testData;
+	}
+
+	/**
+	 * Ensure that a custom config class can actually be used with a custom model class.
+	 *
+	 * @dataProvider dataCustomEntity
+	 */
+	public function testCustomEntity($platform, $config, $requiredExtension, $environment) {
+		$client = $this->initClient($requiredExtension, array('environment' => $environment . '_' . $platform, 'config' => $config));
+		$customSetting = $this->persistSetting(CustomSetting::create('name1', 'value1', 'section1', 'comment1'));
+
+		$customConfig = $client->getContainer()->get('craue_config');
+		$this->assertInstanceOf('Craue\ConfigBundle\Tests\IntegrationTestBundle\Util\CustomConfig', $customConfig);
+
+		$fetchedSetting = $customConfig->getRawSetting('name1');
+		$this->assertSame($customSetting, $fetchedSetting);
+		$this->assertEquals('value1', $customConfig->get('name1'));
+	}
+
+	public function dataCustomEntity() {
+		return self::duplicateTestDataForEachPlatform(array(
+			array('customEntity'),
+		), 'config_customEntity.yml');
+	}
+
+	/**
+	 * Ensure that the database enforces a unique name for settings.
+	 *
+	 * @dataProvider getPlatformConfigs
+	 *
+	 * @expectedException \Doctrine\DBAL\DBALException
+	 * @expectedExceptionMessage An exception occurred while executing 'INSERT INTO craue_config_setting
+	 * @expectedExceptionMessage Integrity constraint violation: 1062 Duplicate entry 'name1' for key 'PRIMARY'
+	 *
+	 * TODO expect \Doctrine\DBAL\Exception\UniqueConstraintViolationException as soon as Doctrine/DBAL >= 2.5 is required
+	 */
+	public function testDefaultEntityNameUnique($platform, $config, $requiredExtension) {
+		$this->initClient($requiredExtension, array('environment' => $platform, 'config' => $config));
+
+		$this->assertSame(array('name'), $this->getEntityManager()->getClassMetadata('Craue\ConfigBundle\Entity\Setting')->getIdentifier());
+
+		$this->persistSetting(Setting::create('name1'));
+		$this->persistSetting(Setting::create('name1'));
+	}
+
+	/**
+	 * Ensure that the database enforces a unique name for settings with a custom entity.
+	 *
+	 * @dataProvider dataCustomEntity
+	 *
+	 * @expectedException \Doctrine\DBAL\DBALException
+	 * @expectedExceptionMessage An exception occurred while executing 'INSERT INTO craue_config_setting_custom
+	 * @expectedExceptionMessage Integrity constraint violation: 1062 Duplicate entry 'name1' for key 'PRIMARY'
+	 *
+	 * TODO expect \Doctrine\DBAL\Exception\UniqueConstraintViolationException as soon as Doctrine/DBAL >= 2.5 is required
+	 */
+	public function testCustomEntityNameUnique($platform, $config, $requiredExtension, $environment) {
+		$this->initClient($requiredExtension, array('environment' => $environment . '_' . $platform, 'config' => $config));
+
+		$this->assertSame(array('name'), $this->getEntityManager()->getClassMetadata('Craue\ConfigBundle\Tests\IntegrationTestBundle\Entity\CustomSetting')->getIdentifier());
+
+		$this->persistSetting(CustomSetting::create('name1'));
+		$this->persistSetting(CustomSetting::create('name1'));
 	}
 
 }

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,8 +1,0 @@
-<?php
-
-use Doctrine\Common\Annotations\AnnotationRegistry;
-
-$loader = require __DIR__.'/../vendor/autoload.php';
-
-// needed for Symfony < 2.7, see https://travis-ci.org/craue/CraueConfigBundle/builds/81349322
-AnnotationRegistry::registerLoader(array($loader, 'loadClass'));

--- a/Tests/config/config_customEntity.yml
+++ b/Tests/config/config_customEntity.yml
@@ -1,0 +1,10 @@
+imports:
+  - { resource: config.yml }
+
+craue_config:
+  entity_name: Craue\ConfigBundle\Tests\IntegrationTestBundle\Entity\CustomSetting
+
+services:
+  craue_config:
+    class: Craue\ConfigBundle\Tests\IntegrationTestBundle\Util\CustomConfig
+    parent: craue_config_default

--- a/Twig/Extension/ConfigTemplateExtension.php
+++ b/Twig/Extension/ConfigTemplateExtension.php
@@ -46,12 +46,6 @@ class ConfigTemplateExtension extends \Twig_Extension {
 	 * {@inheritDoc}
 	 */
 	public function getFilters() {
-		if (version_compare(\Twig_Environment::VERSION, '1.12', '<')) {
-			return array(
-				'craue_sortSections' => new \Twig_Filter_Method($this, 'sortSections'),
-			);
-		}
-
 		return array(
 			new \Twig_SimpleFilter('craue_sortSections', array($this, 'sortSections')),
 		);
@@ -61,12 +55,6 @@ class ConfigTemplateExtension extends \Twig_Extension {
 	 * {@inheritDoc}
 	 */
 	public function getFunctions() {
-		if (version_compare(\Twig_Environment::VERSION, '1.12', '<')) {
-			return array(
-				'craue_setting' => new \Twig_Function_Method($this, 'getSetting'),
-			);
-		}
-
 		return array(
 			new \Twig_SimpleFunction('craue_setting', array($this, 'getSetting')),
 		);

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,5 +1,9 @@
 # Upgrade from 1.x to 2.0
 
+## Database
+
+After upgrading the bundle, you should migrate your database to remove the useless `UNIQUE` index for field `name` from table `craue_config_setting`. The `PRIMARY` index for field `name` will remain.
+
 ## Built-in form/template
 
 - If you're overriding the template `modify_form.html.twig` in your project, you probably need to adapt it to changes in the built-in form type. Before, two hidden form fields `name` and `section` were added only to read their `value` variable in the template. They have been removed now. But you can still access the properties of settings in the template via the `value` variable of each `setting` form field:

--- a/Util/Config.php
+++ b/Util/Config.php
@@ -4,7 +4,7 @@ namespace Craue\ConfigBundle\Util;
 
 use Craue\ConfigBundle\CacheAdapter\CacheAdapterInterface;
 use Craue\ConfigBundle\CacheAdapter\NullAdapter;
-use Craue\ConfigBundle\Entity\Setting;
+use Craue\ConfigBundle\Entity\SettingInterface;
 use Craue\ConfigBundle\Repository\SettingRepository;
 use Doctrine\ORM\EntityManager;
 
@@ -30,6 +30,11 @@ class Config {
 	 */
 	protected $repo;
 
+	/**
+	 * @var string
+	 */
+	protected $entityName;
+
 	public function __construct(CacheAdapterInterface $cache = null) {
 		$this->setCache($cache !== null ? $cache : new NullAdapter());
 	}
@@ -47,6 +52,11 @@ class Config {
 			$this->em = $em;
 			$this->repo = null;
 		}
+	}
+
+	public function setEntityName($entityName) {
+		$this->entityName = $entityName;
+		$this->repo = null;
 	}
 
 	/**
@@ -140,7 +150,7 @@ class Config {
 	}
 
 	/**
-	 * @param Setting[] $entities
+	 * @param SettingInterface[] $entities
 	 * @return array with name => value
 	 */
 	protected function getAsNamesAndValues(array $settings) {
@@ -158,7 +168,7 @@ class Config {
 	 */
 	protected function getRepo() {
 		if ($this->repo === null) {
-			$this->repo = $this->em->getRepository('Craue\ConfigBundle\Entity\Setting');
+			$this->repo = $this->em->getRepository($this->entityName);
 		}
 
 		return $this->repo;

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
 	],
 	"require": {
 		"php": "^5.3.2|~7.0",
+		"doctrine/doctrine-bundle": "~1.3",
 		"symfony/framework-bundle": "~2.3|~3.0"
 	},
 	"require-dev": {
-		"doctrine/doctrine-bundle": "~1.0",
 		"doctrine/doctrine-cache-bundle": "~1.3",
 		"doctrine/orm": "^2.3.1",
 		"phpunit/phpunit": "^4.8.35|~5.7|~6.0",

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,17 @@
 		}
 	],
 	"require": {
-		"php": "^5.3.2|~7.0",
+		"php": "^5.3.9|~7.0",
 		"doctrine/doctrine-bundle": "~1.3",
-		"symfony/framework-bundle": "~2.3|~3.0"
+		"symfony/framework-bundle": "~2.7|~3.0"
 	},
 	"require-dev": {
 		"doctrine/doctrine-cache-bundle": "~1.3",
 		"doctrine/orm": "^2.3.1",
 		"phpunit/phpunit": "^4.8.35|~5.7|~6.0",
-		"symfony/assetic-bundle": "~2.3",
+		"symfony/assetic-bundle": "^2.8.1",
 		"symfony/phpunit-bridge": "~3.2",
-		"symfony/symfony": "~2.3|~3.0"
+		"symfony/symfony": "~2.7|~3.0"
 	},
 	"minimum-stability": "stable",
 	"autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
 		backupGlobals="false"
-		bootstrap="Tests/bootstrap.php"
+		bootstrap="vendor/autoload.php"
 		colors="true"
 		failOnRisky="true"
 		failOnWarning="true">


### PR DESCRIPTION
Resolves #19. I've chosen XML over YAML to avoid a new dependency to `symfony/yaml`.

@Rvanlaak: Could you try this to make sure the mapping can actually be overridden as expected?
