### PR TITLE
avoid deprecation notices with Symfony 2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+- added conditional code updates to avoid deprecation notices with Symfony 2.8
+
 ## 1.3.1 (2015-02-27)
 
 - [#17]: added Russian translation

--- a/Controller/SettingsController.php
+++ b/Controller/SettingsController.php
@@ -3,7 +3,7 @@
 namespace Craue\ConfigBundle\Controller;
 
 use Craue\ConfigBundle\Entity\Setting;
-use Craue\ConfigBundle\Form\ModifySettingsForm;
+use Craue\ConfigBundle\Form\LegacyModifySettingsForm;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Kernel;
@@ -24,7 +24,10 @@ class SettingsController extends Controller {
 			'settings' => $allStoredSettings,
 		);
 
-		$form = $this->createForm(new ModifySettingsForm(), $formData);
+		$form = Kernel::VERSION_ID < 20800
+			? $this->createForm(new LegacyModifySettingsForm(), $formData)
+			: $this->get('form.factory')->createNamed('craue_config_modifySettings', 'Craue\ConfigBundle\Form\ModifySettingsForm', $formData);
+
 		if ($request->getMethod() === 'POST') {
 			if (Kernel::VERSION_ID < 20300) {
 				$form->bind($request);

--- a/DependencyInjection/CraueConfigExtension.php
+++ b/DependencyInjection/CraueConfigExtension.php
@@ -22,7 +22,13 @@ class CraueConfigExtension extends Extension {
 	 */
 	public function load(array $config, ContainerBuilder $container) {
 		$loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
-		$loader->load(Kernel::VERSION_ID < 20700 ? 'form_legacy.xml' : 'form.xml');
+
+		if (Kernel::VERSION_ID < 20700) {
+			$loader->load('form_legacy_legacy.xml');
+		} elseif (Kernel::VERSION_ID < 20800) {
+			$loader->load('form_legacy.xml');
+		}
+
 		$loader->load('twig.xml');
 		$loader->load('util.xml');
 	}

--- a/Form/AbstractModifySettingsForm.php
+++ b/Form/AbstractModifySettingsForm.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Craue\ConfigBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2015 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+abstract class AbstractModifySettingsForm extends AbstractType {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function buildForm(FormBuilderInterface $builder, array $options) {
+		$builder->add('settings', Kernel::VERSION_ID < 20800 ? 'collection' : 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+			'type' => Kernel::VERSION_ID < 20800 ? 'craue_config_setting' : 'Craue\ConfigBundle\Form\Type\SettingType',
+		));
+	}
+
+}

--- a/Form/LegacyModifySettingsForm.php
+++ b/Form/LegacyModifySettingsForm.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace Craue\ConfigBundle\Form\Type;
+namespace Craue\ConfigBundle\Form;
 
 /**
- * for Symfony 2.7
+ * for Symfony < 2.8
  *
  * @author Christian Raue <christian.raue@gmail.com>
  * @copyright 2011-2015 Christian Raue
  * @license http://opensource.org/licenses/mit-license.php MIT License
  */
-class LegacySettingType extends AbstractSettingType {
+class LegacyModifySettingsForm extends AbstractModifySettingsForm {
 
 	/**
 	 * {@inheritDoc}
 	 */
 	public function getName() {
-		return 'craue_config_setting';
+		return 'craue_config_modifySettings';
 	}
 
 }

--- a/Form/ModifySettingsForm.php
+++ b/Form/ModifySettingsForm.php
@@ -2,30 +2,12 @@
 
 namespace Craue\ConfigBundle\Form;
 
-use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilderInterface;
-
 /**
+ * for Symfony >= 2.8
+ *
  * @author Christian Raue <christian.raue@gmail.com>
  * @copyright 2011-2015 Christian Raue
  * @license http://opensource.org/licenses/mit-license.php MIT License
  */
-class ModifySettingsForm extends AbstractType {
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function buildForm(FormBuilderInterface $builder, array $options) {
-		$builder->add('settings', 'collection', array(
-			'type' => 'craue_config_setting',
-		));
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function getName() {
-		return 'craue_config_modifySettings';
-	}
-
+class ModifySettingsForm extends AbstractModifySettingsForm {
 }

--- a/Form/Type/AbstractSettingType.php
+++ b/Form/Type/AbstractSettingType.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Craue\ConfigBundle\Form\Type;
+
+use Craue\ConfigBundle\Entity\Setting;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2015 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+abstract class AbstractSettingType extends AbstractType {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function buildForm(FormBuilderInterface $builder, array $options) {
+		$builder->add('name', Kernel::VERSION_ID < 20800 ? 'hidden' : 'Symfony\Component\Form\Extension\Core\Type\HiddenType');
+		$builder->add('section', Kernel::VERSION_ID < 20800 ? 'hidden' : 'Symfony\Component\Form\Extension\Core\Type\HiddenType');
+		$builder->add('value', Kernel::VERSION_ID < 20800 ? 'text' : 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+			'required' => false,
+		));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function configureOptions(OptionsResolver $resolver) {
+		$resolver->setDefaults(array(
+			'data_class' => get_class(new Setting()),
+		));
+	}
+
+}

--- a/Form/Type/LegacyLegacySettingType.php
+++ b/Form/Type/LegacyLegacySettingType.php
@@ -2,20 +2,22 @@
 
 namespace Craue\ConfigBundle\Form\Type;
 
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
 /**
- * for Symfony 2.7
+ * for Symfony < 2.7
  *
  * @author Christian Raue <christian.raue@gmail.com>
  * @copyright 2011-2015 Christian Raue
  * @license http://opensource.org/licenses/mit-license.php MIT License
  */
-class LegacySettingType extends AbstractSettingType {
+class LegacyLegacySettingType extends LegacySettingType {
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getName() {
-		return 'craue_config_setting';
+	public function setDefaultOptions(OptionsResolverInterface $resolver) {
+		parent::configureOptions($resolver);
 	}
 
 }

--- a/Form/Type/SettingType.php
+++ b/Form/Type/SettingType.php
@@ -2,43 +2,12 @@
 
 namespace Craue\ConfigBundle\Form\Type;
 
-use Craue\ConfigBundle\Entity\Setting;
-use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
-
 /**
+ * for Symfony >= 2.8
+ *
  * @author Christian Raue <christian.raue@gmail.com>
  * @copyright 2011-2015 Christian Raue
  * @license http://opensource.org/licenses/mit-license.php MIT License
  */
-class SettingType extends AbstractType {
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function buildForm(FormBuilderInterface $builder, array $options) {
-		$builder->add('name', 'hidden');
-		$builder->add('section', 'hidden');
-		$builder->add('value', null, array(
-			'required' => false,
-		));
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function configureOptions(OptionsResolver $resolver) {
-		$resolver->setDefaults(array(
-			'data_class' => get_class(new Setting()),
-		));
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function getName() {
-		return 'craue_config_setting';
-	}
-
+class SettingType extends AbstractSettingType {
 }

--- a/Resources/config/form_legacy_legacy.xml
+++ b/Resources/config/form_legacy_legacy.xml
@@ -9,7 +9,7 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 	<services>
-		<service id="craue_config.form_type.setting" class="Craue\ConfigBundle\Form\Type\SettingType">
+		<service id="craue_config.form_type.setting" class="Craue\ConfigBundle\Form\Type\LegacyLegacySettingType">
 			<tag name="form.type" alias="craue_config_setting" />
 		</service>
 	</services>


### PR DESCRIPTION
This PR is meant for trying to avoid as many deprecation notices as possible introduced by symfony/symfony#15079.

I'm pretty sure I've updated all relevant code to not use deprecated functionality while keeping BC. The remaining notices seem to be triggered by Symfony itself.

Travis log:
- pre-PR: https://travis-ci.org/craue/CraueConfigBundle/jobs/73882235
- post-PR: https://travis-ci.org/craue/CraueConfigBundle/jobs/73882878