### PR TITLE
Remove usage of the deprecated target-dir feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,8 @@
 	"minimum-stability": "stable",
 	"prefer-stable": true,
 	"autoload": {
-		"psr-0": {
+		"psr-4": {
 			"Craue\\ConfigBundle\\": ""
 		}
-	},
-	"target-dir": "Craue/ConfigBundle"
+	}
 }


### PR DESCRIPTION
the proper way to autoload such repository layout is to use PSR-4