### PR TITLE
fixed issues with unintentional value changes when using the built-in form

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
             php: '7.3'
             DEPS: 'lowest'
             WITH_DOCTRINE_CACHE_BUNDLE: 'yes'
-            SYMFONY_DEPRECATIONS_HELPER: 'max[self]=2&max[indirect]=1230'
+            SYMFONY_DEPRECATIONS_HELPER: 'max[self]=2&max[indirect]=1394'
           -
             php: '8.2'
             DEPS: 'unmodified'

--- a/Controller/SettingsController.php
+++ b/Controller/SettingsController.php
@@ -37,10 +37,10 @@ class SettingsController extends AbstractController {
 			$form->handleRequest($request);
 
 			if ($form->isSubmitted() && $form->isValid()) {
+				// update the cache
 				foreach ($formData['settings'] as $formSetting) {
 					$storedSetting = $this->getSettingByName($allStoredSettings, $formSetting->getName());
 					if ($storedSetting !== null) {
-						$storedSetting->setValue($formSetting->getValue());
 						$cache->set($storedSetting->getName(), $storedSetting->getValue());
 					}
 				}

--- a/Form/ModifySettingsForm.php
+++ b/Form/ModifySettingsForm.php
@@ -2,9 +2,10 @@
 
 namespace Craue\ConfigBundle\Form;
 
+use Craue\ConfigBundle\Entity\SettingInterface;
 use Craue\ConfigBundle\Form\Type\SettingType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -18,9 +19,16 @@ class ModifySettingsForm extends AbstractType {
 	 * {@inheritDoc}
 	 */
 	public function buildForm(FormBuilderInterface $builder, array $options) : void {
-		$builder->add('settings', CollectionType::class, [
-			'entry_type' => SettingType::class,
-		]);
+		$settingsForm = $builder->create('settings', FormType::class);
+
+		foreach ($options['data']['settings'] as $setting) {
+			/* @var $setting SettingInterface */
+			$settingsForm->add($setting->getName(), SettingType::class, [
+				'data' => $setting,
+			]);
+		}
+
+		$builder->add($settingsForm);
 	}
 
 	/**

--- a/Form/Type/SettingType.php
+++ b/Form/Type/SettingType.php
@@ -5,6 +5,8 @@ namespace Craue\ConfigBundle\Form\Type;
 use Craue\ConfigBundle\Entity\SettingInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -33,6 +35,21 @@ class SettingType extends AbstractType {
 			'required' => false,
 			'translation_domain' => 'CraueConfigBundle',
 		]);
+
+		$builder->addEventListener(FormEvents::PRE_SUBMIT, function(FormEvent $event) : void {
+			$form = $event->getForm();
+			$submittedData = $event->getData();
+
+			// replace non-submitted values by defaults - this avoids nulling values of settings missing from the request
+			// idea from https://stackoverflow.com/questions/11687760/form-avoid-setting-null-to-non-submitted-field/16522446#16522446
+			foreach ($form->all() as $name => $child) {
+				if (!isset($submittedData[$name])) {
+					$submittedData[$name] = $child->getData();
+				}
+			}
+
+			$event->setData($submittedData);
+		});
 	}
 
 	/**

--- a/Tests/IntegrationTestBundle/Entity/CanBeDisabledSetting.php
+++ b/Tests/IntegrationTestBundle/Entity/CanBeDisabledSetting.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Craue\ConfigBundle\Tests\IntegrationTestBundle\Entity;
+
+use Craue\ConfigBundle\Entity\BaseSetting;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2023 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class CanBeDisabledSetting extends BaseSetting {
+
+	/**
+	 * @var bool
+	 */
+	private $disabled = false;
+
+	public function setDisabled(bool $disabled) : void {
+		$this->disabled = $disabled;
+	}
+
+	public function isDisabled() : bool {
+		return $this->disabled;
+	}
+
+	/**
+	 * Creates a {@code CanBeDisabledSetting}.
+	 * @param string $name
+	 * @param string|null $value
+	 * @param string|null $section
+	 * @param bool $disabled
+	 * @return CanBeDisabledSetting
+	 */
+	public static function create($name, $value = null, $section = null, $disabled = false) {
+		$setting = parent::create($name, $value, $section);
+		$setting->setDisabled($disabled);
+
+		return $setting;
+	}
+
+}

--- a/Tests/IntegrationTestBundle/Form/Extension/SettingTypeExtension.php
+++ b/Tests/IntegrationTestBundle/Form/Extension/SettingTypeExtension.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Craue\ConfigBundle\Tests\IntegrationTestBundle\Form\Extension;
+
+use Craue\ConfigBundle\Entity\SettingInterface;
+use Craue\ConfigBundle\Form\Type\SettingType;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2011-2023 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+class SettingTypeExtension extends AbstractTypeExtension {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function buildForm(FormBuilderInterface $builder, array $options) : void {
+		/* @var $formData SettingInterface */
+		$formData = $options['data'];
+
+		$config = $builder->get('value')->getForm()->getConfig();
+
+		$builder->add($config->getName(), get_class($config->getType()->getInnerType()), array_merge($config->getOptions(), [
+			'disabled' => $formData->isDisabled(),
+		]));
+	}
+
+	public static function getExtendedTypes() : iterable {
+		return [SettingType::class];
+	}
+
+}

--- a/Tests/IntegrationTestBundle/Resources/config/doctrine/CanBeDisabledSetting.orm.xml
+++ b/Tests/IntegrationTestBundle/Resources/config/doctrine/CanBeDisabledSetting.orm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+	Author: Christian Raue <christian.raue@gmail.com>
+	Copyright: 2011-2023 Christian Raue
+	License: http://opensource.org/licenses/mit-license.php MIT License
+-->
+<doctrine-mapping
+		xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+	<entity name="Craue\ConfigBundle\Tests\IntegrationTestBundle\Entity\CanBeDisabledSetting" repository-class="Craue\ConfigBundle\Repository\SettingRepository" table="craue_config_setting_can_be_disabled">
+		<field name="value" column="value" type="string" nullable="true" />
+		<field name="disabled" column="disabled" type="boolean" />
+	</entity>
+</doctrine-mapping>

--- a/Tests/config/config_customEntity_canBeDisabled.yml
+++ b/Tests/config/config_customEntity_canBeDisabled.yml
@@ -1,0 +1,9 @@
+imports:
+  - { resource: config.yml }
+
+craue_config:
+  entity_name: Craue\ConfigBundle\Tests\IntegrationTestBundle\Entity\CanBeDisabledSetting
+
+services:
+  Craue\ConfigBundle\Tests\IntegrationTestBundle\Form\Extension\SettingTypeExtension:
+    tags: [form.type_extension]

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.7.x-dev"
+			"dev-master": "3.0.x-dev"
 		},
 		"symfony": {
 			"require": "~4.4|~5.4|^6.3"


### PR DESCRIPTION
This fixes issues with unintentional value changes when using the built-in form to manage settings.

When a new setting is added between rendering and submitting the form, values might be wrongly assigned to other settings. This happens because the settings used to be added as a collection whose fields are usually ordered by the settings' names. Now, if a setting is added in the database, the order of fields could change (depending on the new setting's name) but the submitted values are assigned to fields corresponding to the original order.

Additionally, values of settings not submitted by the form (i.e. not present in the request) used to be effectively set to null.

To illustrate both issues:

1. given settings (and values): name1 (value1), name2 (value2)
2. render the form
3. add new setting name11 (value11) into the database
4. submit the previously rendered form unchanged
5. persisted settings: name1 (value1), name11 (value2), name2 (null)

Now with these fixes, the last step would correctly be:

5. persisted settings: name1 (value1), name11 (value11), name2 (value2)

In order to fix these issues, form field names are now name-based (instead of previously index-based). Thus, form or template customizations need to be revised to reflect these changes.